### PR TITLE
Fix annotations spacing and refactor code

### DIFF
--- a/src/components/common/annotation.py
+++ b/src/components/common/annotation.py
@@ -1,4 +1,4 @@
-from manim import Mobject, ManimColor
+from manim import *
 import functools
 
 
@@ -52,7 +52,7 @@ class Annotation:
         self.color = color
         self.h_spacing = h_spacing
 
-    def __call__(self, scene, exp=None):
+    def __call__(self, scene, exp=None, exp_annotation_buff=0.2):
         left_term = self.left_term
         # if it is find_element_lazy, evaluate it first
         if type(self.left_term) is functools.partial:
@@ -85,4 +85,5 @@ class Annotation:
             right_term=right_term,
             color=self.color,
             h_spacing=self.h_spacing,
+            exp_annotation_buff=exp_annotation_buff,
         )

--- a/src/components/common/base_scene.py
+++ b/src/components/common/base_scene.py
@@ -348,13 +348,13 @@ class MathTutorialScene(VoiceoverScene):
         """Indicate a mobject with a color."""
         return Indicate(mobject, color=color, run_time=run_time)
 
-    def add_annotations(self, term_added, left_term, right_term, color=None, h_spacing=0):
+    def add_annotations(self, term_added, left_term, right_term, color=None, h_spacing=0, exp_annotation_buff=0.2):
         terms = VGroup(*[MathTex(rf"{term_added}").scale(FOOTNOTE_SCALE) for _ in range(2)])
         if color:
             terms.set_color(color)
 
-        terms[0].next_to(left_term, DOWN)
-        terms[1].next_to(right_term, DOWN)
+        terms[0].next_to(left_term, DOWN, buff=exp_annotation_buff)
+        terms[1].next_to(right_term, DOWN, buff=exp_annotation_buff)
 
         # Apply horizontal spacing adjustment
         terms[0].shift(LEFT * h_spacing)  # Move left annotation further left

--- a/src/sandbox/quadratics/quadratic_formula_04/quad_formula_05a.py
+++ b/src/sandbox/quadratics/quadratic_formula_04/quad_formula_05a.py
@@ -160,19 +160,21 @@ class QuadraticFormula(MathTutorialScene):
 
         # solution = VGroup(step1, step2, step3, step4).arrange(DOWN, aligned_edge=LEFT, buff=STEP_BUFF)
             
-        solution = self.create_ordered_steps(step1_list, step2_list, step3_list, step4_list)
-        solution.next_to(question_title_group, DOWN, buff=0.8).align_to(question_title_group, LEFT)
+        solution = self.create_ordered_steps(step1_list, step2_list, step3_list, step4_list,
+            # scale the second element in the first step by 1.5 factor
+            scale_maps = {0: {1: 1.5}})
 
+        solution.next_to(question_title_group, DOWN, buff=0.8).align_to(question_title_group, LEFT)
         step1, step2, step3, step4 = solution
         # solution.arrange(DOWN, aligned_edge=LEFT, buff=STEP_BUFF)
-        print(len(step2))
-        step2_annotation = step2[2]
-        step4_annotation = step4[2]
+        step2_annotation = step2.annotations[0]
+        step4_annotation = step4.annotations[0]
+
         # step2_annotation = step2_expr1[2]  # The annotation part is the third element in the group
         # Step 4 annotations (subtraction of 12)
         # Extract the annotation terms from step4_expr1
         # step4_annotation = step4_expr1[2]  # The annotation part is the third element in the group
-        self.add(step2[3])
+        # self.add(step2[3])
         # self.add(step2_annotation)
         # self.add(step4_annotation)
         # Create individual step elements for ScrollManager including annotations
@@ -190,11 +192,10 @@ class QuadraticFormula(MathTutorialScene):
             *step3,
             *step4,
         )
-        
         pre_scroll_mgr = ScrollManager(pre_ordered_steps)
         
         
-         ###############################################################################
+        ###############################################################################
         # IDENTIFY COEFFICIENTS
         ###############################################################################
         
@@ -371,15 +372,16 @@ class QuadraticFormula(MathTutorialScene):
         )
         
         self.play(Write(question_title_group))
-        
+
         pre_scroll_mgr.prepare_next(self)  # Shows step1_label
         pre_scroll_mgr.prepare_next(self)  # Shows step1_expr
 
         pre_scroll_mgr.prepare_next(self)  # Shows step2_label
         pre_scroll_mgr.prepare_next(self)  # Shows main expression (step2_expr1[0])
         
-        self.play(FadeIn(step2_annotation))
-        pre_scroll_mgr.current_position += 1  # Manually update position
+        # self.play(FadeIn(step2_annotation))
+        # pre_scroll_mgr.current_position += 1  # Manually update position
+        pre_scroll_mgr.prepare_next(self, animation_type=FadeIn)  # Shows step2_annotation
         
         pre_scroll_mgr.prepare_next(self)  # Shows step2_expr2
         
@@ -392,11 +394,15 @@ class QuadraticFormula(MathTutorialScene):
 
         pre_scroll_mgr.prepare_next(self)  # Shows step4_label
         pre_scroll_mgr.prepare_next(self)  # Shows step4_expr1
-        self.play(FadeIn(step4_annotation))
-        pre_scroll_mgr.current_position += 1  # Manually update position
+
+        pre_scroll_mgr.prepare_next(self, animation_type=FadeIn)  # Shows step4_annotation
+        # self.play(FadeIn(step4_annotation))
+        # pre_scroll_mgr.current_position += 1  # Manually update position
         pre_scroll_mgr.prepare_next(self)  # Shows step4_expr2
         
-        self.play(FadeOut(solution))
+        # self.play(FadeOut(solution))
+        pre_scroll_mgr.fade_out_all_in_view(self)
+
         
         # scroll_mgr.prepare_next(self)
 


### PR DESCRIPTION
- [x] Add custom and default scaling to step creation
- [x] Fix annotation spacing
- [x] Add a step class to fetch elements easily (for example `step.annotations[0]`, etc)
- [x] Add a function to fade out in view elements in scroll manager instead of calling `FadeOut`
- [x] Get rid of manual updates of positions in scroll manager (there was a problem with prepare_next) 
- [ ] Add support for multiple annotation for the same the expression (needs decision)
